### PR TITLE
ensure repeat count is at least 0

### DIFF
--- a/lib/Text/Indent.pm
+++ b/lib/Text/Indent.pm
@@ -300,7 +300,7 @@ sub indent
     my $self = shift;
     my @args = @_;
     
-    return ($self->spacechar x ($self->spaces * $self->level)) .
+    return ($self->spacechar x ($self->spaces * ($self->level < 0 ? 0 : $self->level))) .
            "@args" . ($self->add_newline ? "\n" : '');
     
 }


### PR DESCRIPTION
For Perl version 5.22.0 onward, 09_indent.t is failing with the following error message:
Negative repeat count does nothing at /home/perl/src/Text-Indent/lib/Text/Indent.pm line 303.

This warning was introduced in 5.21, as seen here:
http://perldoc.perl.org/perl5211delta.html#New-Diagnostics

This commit fixes the warning by setting the repeat count to 0 if indent is less than 0.